### PR TITLE
Fixing initial example for first-timers

### DIFF
--- a/game_resources/example_planets.json
+++ b/game_resources/example_planets.json
@@ -4,7 +4,7 @@
       "name": "planet_a",
       "size": "s",
       "resources": 4,
-      "connections": ["planet_b", "planet_c"]
+      "connections": ["planet_b", "planet_c", "planet_d"]
     },
     {
       "name": "planet_b",


### PR DESCRIPTION
Getting my planets generated was a stumbling point when I first got set up.

## The problem:

I copy-pasted the example to match the default planet game data _(game_resources/planets.json)_, only to find that `planet.py generate_planets` cannot interpret the file:
> planet_d lists planet_a as a connection, but planet_a does not list planet_d. Connections must be bi-directional.

## This solution:

Makes the connection between planet_a and planet_d in the initial example be bidirectional.