### PR TITLE
Add docker for python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.9.2-slim
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install -r requirements.txt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,41 @@
+version: "3.9"
+
+services:
+
+  # 
+  # For running any general python commands for this project.
+  # Note that dependencies are baked into the base image.
+  # 
+  # USAGE:
+  # 
+  #   docker-compose run python 
+  #   docker-compose run python planet.py --help
+  #   docker-compose run python faction.py --help
+  #   docker-compose run python ship.py --help
+  #   docker-compose run python facility.py --help
+  #   docker-compose run python report.py --help
+  # 
+  python:
+    build: .
+    entrypoint: python
+    volumes:
+      - .:/app
+    environment:
+      DATABASE_URL: ${DATABASE_URL:? add DATABASE_URL=sqlite:///your-name.db to .env file}
+    stdin_open: true # docker run -i
+    tty: true        # docker run -t
+
+  # 
+  # For debugging this docker-compose environment or experimenting.
+  # 
+  # USAGE:
+  # 
+  #   docker-compose run debug
+  #
+  debug:
+    build: .
+    volumes:
+      - .:/app
+    entrypoint: /bin/bash
+    stdin_open: true # docker run -i
+    tty: true        # docker run -t

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,11 +9,11 @@ services:
   # USAGE:
   # 
   #   docker-compose run python 
-  #   docker-compose run python planet.py --help
-  #   docker-compose run python faction.py --help
-  #   docker-compose run python ship.py --help
-  #   docker-compose run python facility.py --help
-  #   docker-compose run python report.py --help
+  #   docker-compose run python planet.py
+  #   docker-compose run python faction.py
+  #   docker-compose run python ship.py
+  #   docker-compose run python facility.py
+  #   docker-compose run python report.py
   # 
   python:
     build: .


### PR DESCRIPTION
Adds docker support for all those who bemoan broken python environments.

## The problem:

Python is not very well-standardized or compartmentalized when it comes to its build environment.  Sure, venv gets you most of the way there, but the README still needs to be interpreted by someone who is aware of discrepancies in pip/pip3, python2/python3/python, and requirements can still blow up depending on the environment you run them in.

Generally, the problem here is that "it works on my machine."

## The solution:

Docker.

One standardized container.  It bakes in the requirements up-front in the Dockerfile.

If desired, you can directly use docker:
```sh
docker build . -t spacegame
docker run -v `pwd`:/app spacegame python planet.py
```

Or, you can skip to the good part - `docker-compose` tucks all that away and adds the following:
```sh
# Run volume-mounted files:
docker-compose run python whatever_you_want.py --however you --want it

# Run python REPL:
docker-compose run python

# Run a debugging container to see what's on the image:
docker-compose run debug
```